### PR TITLE
Add support for client side SSL certificates

### DIFF
--- a/crowd.py
+++ b/crowd.py
@@ -31,14 +31,18 @@ class CrowdServer(object):
     The ``ssl_verify`` parameter controls how and if certificates are verified.
     If ``True``, the SSL certificate will be verified.
     A CA_BUNDLE path can also be provided.
+    
+    The ``client_cert`` tuple (cert,key) specifies a SSL client certificate and key files.
     """
 
-    def __init__(self, crowd_url, app_name, app_pass, ssl_verify=True, timeout=None):
+    def __init__(self, crowd_url, app_name, app_pass, ssl_verify=True, 
+                 timeout=None, client_cert=None):
         self.crowd_url = crowd_url
         self.app_name = app_name
         self.app_pass = app_pass
         self.rest_url = crowd_url.rstrip("/") + "/rest/usermanagement/1"
         self.ssl_verify = ssl_verify
+        self.client_cert = client_cert
         self.timeout = timeout
 
         self.session = self._build_session(content_type='json')
@@ -58,6 +62,7 @@ class CrowdServer(object):
         }
         session = requests.Session()
         session.verify = self.ssl_verify
+        session.cert = self.client_cert
         session.auth = requests.auth.HTTPBasicAuth(self.app_name, self.app_pass)
         session.headers.update(headers)
         return session


### PR DESCRIPTION
This enables support for specifying a client side SSL certificate when authenticating against the Crowd server. This is useful for institutions which use two factor authentication with Crowd. This should have no effect for anyone who doesn't use this option.