### PR TITLE
Fix missing encoding for long_description in setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,3 +94,4 @@ to the end of this list and include the change in your pull request.
 * Christian Schläppi (@nevious)
 * Yuichi Tokutomi (@Tommy1969)
 * Attila Bogár (@attilabogar)
+* Jascha Geerds (@jgeerds)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+import codecs
 import os.path
 __dir__ = os.path.dirname(os.path.abspath(__file__))
 
@@ -10,7 +11,8 @@ setup(
     install_requires=['requests', 'lxml'],
 
     description='A python client to the Atlassian Crowd REST API',
-    long_description=open(os.path.join(__dir__, 'README.rst')).read(),
+    long_description=codecs.open(os.path.join(__dir__, 'README.rst'),
+                                 encoding='utf-8').read(),
 
     author='Alexander Else',
     author_email='aelse@else.id.au',


### PR DESCRIPTION
This fixes package installation when the default system encoding is not `UTF-8` (e.g. `LANG=C`). The built-in `codecs` package works for python2 and python3.