### PR TITLE
resolve issue-44 search method should support start_index and max_results

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,3 +95,4 @@ to the end of this list and include the change in your pull request.
 * Yuichi Tokutomi (@Tommy1969)
 * Attila Bogár (@attilabogar)
 * Jascha Geerds (@jgeerds)
+* John Christian (@potus98)

--- a/crowd.py
+++ b/crowd.py
@@ -628,7 +628,7 @@ class CrowdServer(object):
             memberships[group] = {u'users': users, u'groups': groups}
         return memberships
 
-    def search(self, entity_type, property_name, search_string):
+    def search(self, entity_type, property_name, search_string, start_index=0, max_results=99999):
         """Performs a user search using the Crowd search API.
 
         https://developer.atlassian.com/display/CROWDDEV/Crowd+REST+Resources#CrowdRESTResources-SearchResource
@@ -637,6 +637,8 @@ class CrowdServer(object):
             entity_type: 'user' or 'group'
             property_name: eg. 'email', 'name'
             search_string: the string to search for.
+            start_index: starting index of the results (default: 0)
+            max_results: maximum number of results returned (default: 99999)
 
         Returns:
             json results:
@@ -656,6 +658,8 @@ class CrowdServer(object):
         params = {
             'entity-type': entity_type,
             'expand': entity_type,
+            'start-index': start_index,
+            'max-results': max_results
         }
         # Construct XML payload of the form:
         # <property-search-restriction>


### PR DESCRIPTION
@hdost , et.al.,

This pull request addresses issue-44 "search method should support start_index and max_results"

The change adds support for CROWD API search parameters "start_index" and "max_results" but should still maintain backwards compatibility (or at least not break) existing scripts suing python-crowd module.

Please review and provide any feedback or recommendations. Thank you for your help! 
-John Christian