### PR TITLE
Fix for #42 - Fix the params variable validationFactors when validating session

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,3 +96,4 @@ to the end of this list and include the change in your pull request.
 * Attila Bogár (@attilabogar)
 * Jascha Geerds (@jgeerds)
 * John Christian (@potus98)
+* Maiko Bossuyt (@maiko)

--- a/crowd.py
+++ b/crowd.py
@@ -281,7 +281,7 @@ class CrowdServer(object):
         }
 
         if proxy:
-            params["validation-factors"]["validationFactors"].append({"name": "X-Forwarded-For", "value": proxy, })
+            params["validationFactors"].append({"name": "X-Forwarded-For", "value": proxy, })
 
         url = self.rest_url + "/session/%s" % token
         response = self._post(url, data=json.dumps(params), params={"expand": "user"})

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name='Crowd',
     license='BSD',
     py_modules=['crowd'],
-    version='2.0.0',
+    version='2.0.1',
     install_requires=['requests', 'lxml'],
 
     description='A python client to the Atlassian Crowd REST API',


### PR DESCRIPTION
This pull request address issue #42 "params variable is defined incorrectly on line 284"

Based on the recommendation by @mobile09 in #42, I've corrected line 284 in crowd.py and I was able to confirm that this fix is working as expected when validating a session with a user passing through a proxy. 

I've encountered the same issue and fixed it internally, though it was a good idea to get it fixed upstream ;) 

I've only bump the minor version since this is not a big change in functionality but only a fix. 

Thanks,
Maiko 