### PR TITLE
Bump python3 requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.7"
+  - "3.6"
   - "3.5"
   - "2.7"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
-  - "3.4"
+  - "3.7"
+  - "3.5"
   - "2.7"
 install:
   - pip install .

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: System :: Systems Administration :: Authentication/Directory",
     ]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name='Crowd',
     license='BSD',
     py_modules=['crowd'],
-    version='2.0.1',
+    version='3.0.0',
     install_requires=['requests', 'lxml'],
 
     description='A python client to the Atlassian Crowd REST API',


### PR DESCRIPTION
lxml specified in setup.py now requres python 3.5+. This change sets that requirement as 3.4 is EOL. The last time python-crowd support was removed for a 3.x python version (#49) we did a major version bump so that's the case now also. 